### PR TITLE
feat(textfield): add unhide/hide icon

### DIFF
--- a/src/components/Iconography/Icon.jsx
+++ b/src/components/Iconography/Icon.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from '@xstyled/styled-components'
-import { color, th } from '@xstyled/system'
+import { color, th, space } from '@xstyled/system'
 import PropTypes from 'prop-types'
 
 import * as Icons from '../../icons'
@@ -16,6 +16,7 @@ const Icon = styled(IconComponent)`
     fill: ${({ color }) => th.color(color)};
   }
   ${color}
+  ${space}
 `
 
 Icon.defaultProps = {

--- a/src/components/TextField/TextField.jsx
+++ b/src/components/TextField/TextField.jsx
@@ -2,31 +2,44 @@ import React, { useState, forwardRef } from 'react'
 import styled, { css } from '@xstyled/styled-components'
 import { variant } from '@xstyled/system'
 
+import { Icon } from '../Iconography'
 import { Flex, Box } from '../Grid'
 import { Caption, Typography } from '..'
 
-const TextField = forwardRef(({ label, message, prefix, suffix, placeholder, disabled, type, name, ...props }, ref) => {
-  const [focus, setFocus] = useState(false)
-  return (
-    <Wrapper disabled={disabled} {...props}>
-      <Label>{label}</Label>
-      <Container focus={focus}>
-        {prefix && <Affix forwardedAs='span'>{prefix}</Affix>}
-        <InputBase
-          ref={ref}
-          type={type}
-          name={name}
-          placeholder={placeholder}
-          onFocus={() => setFocus(true)}
-          onBlur={() => setFocus(false)}
-          disabled={disabled}
-        />
-        {suffix && <Affix forwardedAs='span'>{suffix}</Affix>}
-      </Container>
-      <Message>{message}</Message>
-    </Wrapper>
-  )
-})
+const TextField = forwardRef(
+  ({ label, message, prefix, suffix, placeholder, disabled, type, name, password, ...props }, ref) => {
+    const [focus, setFocus] = useState(false)
+    const [inputType, setInputType] = useState(type)
+
+    return (
+      <Wrapper disabled={disabled} {...props}>
+        <Label>{label}</Label>
+        <Container focus={focus}>
+          {prefix && <Affix forwardedAs='span'>{prefix}</Affix>}
+          <InputBase
+            ref={ref}
+            type={inputType}
+            name={name}
+            placeholder={placeholder}
+            onFocus={() => setFocus(true)}
+            onBlur={() => setFocus(false)}
+            disabled={disabled}
+          />
+          {password && (
+            <Icon
+              onMouseOver={() => setInputType('text')}
+              onMouseOut={() => setInputType('password')}
+              icon='visibility'
+              pr={3}
+            />
+          )}
+          {suffix && <Affix forwardedAs='span'>{suffix}</Affix>}
+        </Container>
+        <Message>{message}</Message>
+      </Wrapper>
+    )
+  }
+)
 
 const errorVariant = variant({
   prop: 'error',

--- a/src/stories/TextField.stories.mdx
+++ b/src/stories/TextField.stories.mdx
@@ -94,4 +94,31 @@ O `TextField` pode receber a prop de `disabled`, que desabilita todo o seu uso.
   </Story>
 </Preview>
 
+# Password
+
+O `TextField` pode receber a prop de `password`, que insere o ícone para mostrar ou ocultar a senha.
+
+<Preview>
+  <Story
+    name='Password'
+    parameters={{
+      design: {
+        type: 'figma',
+        url: 'https://www.figma.com/file/O3bKxIcsj2rc1FNIRclJyT/Design-System?node-id=213%3A87'
+      }
+    }}
+  >
+    <ThemeProvider>
+      <TextField
+        type='password'
+        name='password'
+        label='Password'
+        placeholder='Password TextField'
+        message='Password'
+        password
+      />
+    </ThemeProvider>
+  </Story>
+</Preview>
+
 <Props of={TextField} />


### PR DESCRIPTION
## O que foi feito neste PR
Foi desenvolvido uma propriedade que quando usada define que aquele campo trata dados do tipo senha, logo um ícone à extrema direita do TextField é inserido, que tem a função de mostrar a senha ou ocultá-la.
Atualmente isso funciona por eventos acionados quando o mouse está em cima.

**Foi feita uma [alteração](https://github.com/naveteam/saturn/blob/90b2839f06abddcb21bbe0cc31c1149be42b94ab/src/components/Iconography/Icon.jsx) no componente `Iconography`, inserindo à ele o `${space}` do `Styled System`, para eu poder definir o espaçamento do ícone dentro da `TextField`, nada que compromete seu funcionamento.**

## Funcionamento
Normal
![image](https://user-images.githubusercontent.com/34246280/91202319-05a14180-e6d8-11ea-9d54-e7ab3de1fb00.png)

Quando o mouse estiver sobre o ícone.
![image](https://user-images.githubusercontent.com/34246280/91202344-0f2aa980-e6d8-11ea-95aa-3fee337e7312.png)


## Cards relacionados e links externos
- Não se aplica